### PR TITLE
Add support for parsing hosts from The Dude CSV exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,28 @@ host:
     password: "secret"
 ```
 
+- CSV export from The Dude:
+
+  Hosts can be specified in CSV format as exported by [The Dude](https://www.mikrotik.com/thedude).
+
+  The Dude does not export username or password so these must be specified in the main configuration file.
+
+  1. Open The Dude client and connect to your server.
+  2. Select the List tab on the Devices pane.
+  3. Click the "CSV" button to export all devices. All rows that are not "RouterOS" devices are ignored when
+     the CSV file is read.
+
+  Expected CSV format:
+
+  ```csv
+  Flag,Name,Addresses,MAC,Type,Maps,Services Down,Notes
+  up,192.168.88.1,192.168.88.1,"7E:4D:28:00:00:00, 7E:4D:28:00:00:01, 7E:4D:28:00:00:04",RouterOS,Local,,
+  up,192.168.88.104,192.168.88.104,BE:4E:26:00:00:00,Some Device,Local,,
+  ```
+
+  Note that in the above example, only 192.168.88.1 will be considered valid as it is the only row with
+  the Type of "RouterOS". Rows of any other type will be ignored and not connected to.
+
 ### Detailed configuration descriptions
 
 - [MT-bulk command line tool](./docs/configuration-mt-bulk.md#MT-bulk-configuration)

--- a/examples/configurations/hosts.example.csv
+++ b/examples/configurations/hosts.example.csv
@@ -1,0 +1,3 @@
+Flag,Name,Addresses,MAC,Type,Maps,Services Down,Notes
+up,192.168.88.1,192.168.88.1,"7E:4D:28:00:00:00, 7E:4D:28:00:00:01, 7E:4D:28:00:00:04",RouterOS,Local,,
+up,192.168.88.104,192.168.88.104,BE:4E:26:00:00:00,Some Device,Local,,

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	github.com/go-routeros/routeros v0.0.0-20190905230431-4e69e5fc3b22 // indirect
+	github.com/gocarina/gocsv v0.0.0-20201208093247-67c824bc04d4
 	github.com/gorilla/mux v1.7.3
 	github.com/lib/pq v1.2.0
 	github.com/migotom/routeros v0.0.0-20181221124051-7e6c4656571f

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-routeros/routeros v0.0.0-20190905230431-4e69e5fc3b22 h1:C6c62mxsyTBNZVXQ5nuWfNkYCsfklS7Ji0IR5+f1KQQ=
 github.com/go-routeros/routeros v0.0.0-20190905230431-4e69e5fc3b22/go.mod h1:em1mEqFKnoeQuQP9Sg7i26yaW8o05WwcNj7yLhrXxSQ=
+github.com/gocarina/gocsv v0.0.0-20201208093247-67c824bc04d4 h1:Q7s2AN3DhFJKOnzO0uTKLhJTfXTEcXcvw5ylf2BHJw4=
+github.com/gocarina/gocsv v0.0.0-20201208093247-67c824bc04d4/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=

--- a/internal/driver/file.go
+++ b/internal/driver/file.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/gocarina/gocsv"
 	"gopkg.in/yaml.v2"
 
 	"github.com/BurntSushi/toml"
@@ -36,6 +37,22 @@ func FileLoadJobs(ctx context.Context, jobTemplate entities.Job, filename string
 		if err != nil {
 			return nil, err
 		}
+    case ".csv":
+        type H struct {
+            IP string `csv:"Addresses"`
+            Type string `csv:"Type"`
+        }
+        var hs []H
+        err = gocsv.UnmarshalBytes(content, &hs)
+        if err != nil {
+            return nil, err
+        }
+        for _, h := range hs {
+            // csv export from The Dude contains all Devices, so filter out everything that is not RouterOS
+            if h.Type == "RouterOS" {
+                hosts.Host = append(hosts.Host, entities.Host{IP: h.IP})
+            }
+        }
 	default:
 		reader := bytes.NewReader(content)
 		scanner := bufio.NewScanner(reader)


### PR DESCRIPTION
Hi there! Thanks for building this tool, it has been immensely helpful.

I'm using this tool to run commands against devices I have registered in The Dude. It does not appear to be possible to run a custom Tool in The Dude against more than one mikrotik at a time, so instead I'm using the CSV export option on the Devices listing in The Dude client to generate a list of hosts. Then I can use mt-bulk with the CSV as the sources-file along with a default username/password in the config to make magic happen.

The default format for the CSV export is like the following, with the `Addresses` column translating to the `IP` field on a Host:
```
Flag,Name,Addresses,MAC,Type,Maps,Services Down,Notes
up,192.168.222.1,192.168.222.1,"7E:4D:28:00:00:00, 7E:4D:28:00:00:01, 7E:4D:28:00:00:04",RouterOS,Local,,
up,192.168.222.104,192.168.222.104,BE:4E:26:00:00:00,Some Device,Local,,
```

The CSV from the Devices tab is used and contains all Devices as the export from the RouterOS listing in The Dude does not contain the `Addresses` field. Because of this, there is an extra step to filter out non "RouterOS" rows, compared to the other hosts file parsers. The Dude does not export username or password, so these must be specified in the main mt-bulk config.

I realize this may be a bit of a niche use-case, but The Dude is fairly popular in the MikroTik world so I figured it would be worth trying to contribute back to the project repo. I'd be happy to add a short section in the README about the format parsing too, just want to make sure this is even wanted before doing so.
